### PR TITLE
Dockerfile with vLLM dedicated to run on CPU (Xeon).

### DIFF
--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -6,7 +6,7 @@
 #
 # Build arguments:
 #   PYTHON_VERSION=3.13|3.12 (default)|3.11|3.10
-#   VLLM_VERSION=main (default)|<tag>|<branch>
+#   VLLM_VERSION=v0.12.0 (default)|<tag>|<branch>
 #   VLLM_CPU_DISABLE_AVX512=false (default)|true
 #   VLLM_CPU_AVX512BF16=true (default)|false
 #   VLLM_CPU_AVX512VNNI=true (default)|false
@@ -40,7 +40,8 @@ FROM toolchain-ubi${UBI_VERSION} AS base
 
 ARG PYTHON_VERSION=3.12
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
-ARG VLLM_VERSION="main"
+# Last commit of v0.12.0 release: 4fd9d6a85c00ac0186aa9abbeff73fc2ac6c721e, 03.12.2025 (dd/mm/yyyy)
+ARG VLLM_VERSION="releases/v0.12.0"
 ARG NUMACTL_VERSION=2.0.19
 ARG MARCH="sapphirerapids"
 

--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -5,10 +5,10 @@
 #
 # Build arguments:
 #   PYTHON_VERSION=3.13|3.12 (default)|3.11|3.10
-#   VLLM_VERSION=v0.10.0 (default)|latest|main|<tag>|<branch>
+#   VLLM_VERSION=v0.11.0 (default)|latest|main|<tag>|<branch>
 #   VLLM_CPU_DISABLE_AVX512=false (default)|true
-#   VLLM_CPU_AVX512BF16=false (default)|true
-#   VLLM_CPU_AVX512VNNI=false (default)|true
+#   VLLM_CPU_AVX512BF16=true (default)|false
+#   VLLM_CPU_AVX512VNNI=true (default)|false
 
 ###############################
 # Stage 1: Base Image
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi10 AS base
 
 ARG PYTHON_VERSION=3.12
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
-ARG VLLM_VERSION="v0.10.0"
+ARG VLLM_VERSION="v0.11.0"
 ARG NUMACTL_VERSION=2.0.19
 
 USER 0
@@ -38,6 +38,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
 # Set build environment variables
 ENV CFLAGS="-O3 -mavx2 -mf16c -fopenmp"
 ENV CXXFLAGS="${CFLAGS}"
+ENV LD_LIBRARY_PATH="/usr/local/lib:"
 ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/venv"
 ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
@@ -63,17 +64,16 @@ RUN --mount=type=cache,target=/tmp/numactl-build \
     make install && \
     ldconfig
 
-# Clone vLLM source code at specific version
-# RUN git clone --depth 1 --branch $VLLM_VERSION https://github.com/vllm-project/vllm.git && \
-#     cd vllm && \
-#     git log --oneline -1
+RUN git clone --depth 1 --branch $VLLM_VERSION https://github.com/vllm-project/vllm.git && \
+    cd vllm && \
+    git log --oneline -1
+
+WORKDIR /workspace/vllm
 
 # Install vLLM build and runtime dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,src=requirements/common.txt,target=requirements/common.txt \
-    --mount=type=bind,src=requirements/cpu.txt,target=requirements/cpu.txt \
     uv pip install --upgrade pip && \
-    uv pip install -r requirements/cpu.txt
+    uv pip install -r requirements/cpu.txt --no-build-isolation
 
 ###############################
 # Stage 2: Build Environment
@@ -91,7 +91,6 @@ ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
 ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
 
 WORKDIR /workspace/vllm
-COPY . .
 
 # Optional repository check
 RUN if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
@@ -110,24 +109,39 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ###############################
 FROM registry.access.redhat.com/ubi10 AS runtime
 
-# Pass Python version to runtime stage
 ARG PYTHON_VERSION=3.12
+ARG GPERFTOOLS_VERSION=2.17.2
 
 # Runtime environment variables
 # https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#related-runtime-environment-variables
-ARG VLLM_CPU_KVCACHE_SPACE=0
+# Larger space can support more concurrent requests, longer context length.
+ARG VLLM_CPU_KVCACHE_SPACE=64
 ARG VLLM_CPU_OMP_THREADS_BIND=auto
-ARG VLLM_CPU_NUM_OF_RESERVED_CPU=None
-ARG CPU_VISIBLE_MEMORY_NODES=
+# - Note, it is recommended to manually reserve 1 CPU for vLLM front-end process when world_size == 1.
+#   - Unset VLLM_CPU_NUM_OF_RESERVED_CPU for world size > 1
+ARG VLLM_CPU_NUM_OF_RESERVED_CPU=1
+ARG CPU_VISIBLE_MEMORY_NODES
+# Requires AMX CPU flag (SPR and onwards).
 ARG VLLM_CPU_MOE_PREPACK=1
-ARG VLLM_CPU_SGL_KERNEL=0
+# The kernels require AMX instruction set, BFloat16 weight type and weight shapes divisible by 32. 
+# Set to 1 to enable if your CPU supports it.
+ARG VLLM_CPU_SGL_KERNEL=1
+# Controls the number of threads used by PyTorch's TorchInductor compiler for optimization.
+ARG TORCHINDUCTOR_COMPILE_THREADS=1
+# Bypasses vLLM's safety check that enforces the model's maximum sequence length limit.
+ARG VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+ARG VLLM_ENGINE_ITERATION_TIMEOUT_S=600
 
+ENV GPERFTOOLS_VERSION=${GPERFTOOLS_VERSION}
 ENV VLLM_CPU_KVCACHE_SPACE=${VLLM_CPU_KVCACHE_SPACE}
 ENV VLLM_CPU_OMP_THREADS_BIND=${VLLM_CPU_OMP_THREADS_BIND}
 ENV VLLM_CPU_NUM_OF_RESERVED_CPU=${VLLM_CPU_NUM_OF_RESERVED_CPU}
 ENV CPU_VISIBLE_MEMORY_NODES=${CPU_VISIBLE_MEMORY_NODES}
 ENV VLLM_CPU_MOE_PREPACK=${VLLM_CPU_MOE_PREPACK}
 ENV VLLM_CPU_SGL_KERNEL=${VLLM_CPU_SGL_KERNEL}
+ENV TORCHINDUCTOR_COMPILE_THREADS=${TORCHINDUCTOR_COMPILE_THREADS}
+ENV VLLM_ALLOW_LONG_MAX_MODEL_LEN=${VLLM_ALLOW_LONG_MAX_MODEL_LEN}
+ENV VLLM_ENGINE_ITERATION_TIMEOUT_S=${VLLM_ENGINE_ITERATION_TIMEOUT_S}
 
 USER 0
 WORKDIR /workspace
@@ -135,9 +149,9 @@ WORKDIR /workspace
 # Install Python 3.12 specifically and minimal runtime dependencies
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf -y update && \
-    dnf install -y --setopt=tsflags=nodocs python3.12 python3.12-pip && \
+    dnf install -y --setopt=tsflags=nodocs --skip-broken wget python3.12 python3.12-devel python3.12-pip openssl gcc-c++ && \
     dnf clean all && \
-    # Create symlinks to make Python 3.12 the default python3
+    rm -rf /var/cache/dnf/* && \
     ln -sf /usr/bin/python3.12 /usr/bin/python3 && \
     ln -sf /usr/bin/pip3.12 /usr/bin/pip3
 
@@ -146,8 +160,16 @@ COPY --from=base /usr/local/lib/libnuma* /usr/local/lib/
 COPY --from=base /usr/local/bin/numa* /usr/local/bin/
 COPY --from=builder /workspace/vllm /workspace/vllm
 
-# Set up environment
-ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+RUN --mount=type=cache,target=/tmp/gperftools-build \
+cd /tmp/gperftools-build && \
+    wget -O gperftools-${GPERFTOOLS_VERSION}.tar.gz \
+      "https://github.com/gperftools/gperftools/releases/download/gperftools-${GPERFTOOLS_VERSION}/gperftools-${GPERFTOOLS_VERSION}.tar.gz" && \
+    tar xf gperftools-${GPERFTOOLS_VERSION}.tar.gz && \
+    cd gperftools-${GPERFTOOLS_VERSION} && \
+    ./configure --prefix=/usr/local --enable-minimal && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig
 
 # Install vLLM wheel using Python 3.12 (no UV needed in runtime)
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
@@ -156,6 +178,10 @@ RUN --mount=type=bind,from=builder,src=/workspace/vllm/dist,target=/tmp \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install /tmp/*.whl && \
     ldconfig
+
+# Set up environment
+ENV LD_LIBRARY_PATH="/usr/local/lib:"
+ENV LD_PRELOAD="/usr/local/lib/libtcmalloc_minimal.so.4:/usr/local/lib/libiomp5.so"
 
 # Set system-wide core dump limits
 RUN echo "* soft core 0" >> /etc/security/limits.conf && \
@@ -170,7 +196,6 @@ RUN python3 -c "import sys; print(f'Python version: {sys.version}')" && \
     numactl --version
 
 USER 1001
-WORKDIR /workspace/vllm
 
 # Start vLLM server using Python 3.12
 ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -155,7 +155,7 @@ ARG CPU_VISIBLE_MEMORY_NODES
 # Requires AMX CPU flag (SPR and onwards).
 ARG VLLM_CPU_MOE_PREPACK=1
 # The kernels require AMX instruction set, BFloat16 weight type and weight shapes divisible by 32. 
-# Set to 1 to enable if your CPU supports it. Works on UBI10, but not UBI9 due to older glibc.
+# Set to 1 to enable if your CPU supports it.
 ARG VLLM_CPU_SGL_KERNEL=1
 # Controls the number of threads used by PyTorch's TorchInductor compiler for optimization.
 ARG TORCHINDUCTOR_COMPILE_THREADS=1

--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -10,10 +10,12 @@
 #   VLLM_CPU_AVX512BF16=true (default)|false
 #   VLLM_CPU_AVX512VNNI=true (default)|false
 
+ARG UBI_VERSION=9
+
 ###############################
 # Stage 1: Base Image
 ###############################
-FROM registry.access.redhat.com/ubi10 AS base
+FROM registry.access.redhat.com/ubi${UBI_VERSION} AS base
 
 ARG PYTHON_VERSION=3.12
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
@@ -107,7 +109,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ###############################
 # Stage 3: Runtime Environment
 ###############################
-FROM registry.access.redhat.com/ubi10 AS runtime
+FROM registry.access.redhat.com/ubi${UBI_VERSION} AS runtime
 
 ARG PYTHON_VERSION=3.12
 ARG GPERFTOOLS_VERSION=2.17.2
@@ -124,7 +126,7 @@ ARG CPU_VISIBLE_MEMORY_NODES
 # Requires AMX CPU flag (SPR and onwards).
 ARG VLLM_CPU_MOE_PREPACK=1
 # The kernels require AMX instruction set, BFloat16 weight type and weight shapes divisible by 32. 
-# Set to 1 to enable if your CPU supports it.
+# Set to 1 to enable if your CPU supports it. Works on UBI10, but not UBI9 due to older glibc.
 ARG VLLM_CPU_SGL_KERNEL=1
 # Controls the number of threads used by PyTorch's TorchInductor compiler for optimization.
 ARG TORCHINDUCTOR_COMPILE_THREADS=1

--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -1,0 +1,176 @@
+# Multi-stage vLLM Dockerfile for CPU-only UBI 10
+# Stage 1: Build environment with all development tools
+# Stage 2: Build vLLM wheel
+# Stage 3: Minimal runtime environment with vLLM installed
+#
+# Build arguments:
+#   PYTHON_VERSION=3.13|3.12 (default)|3.11|3.10
+#   VLLM_VERSION=v0.10.0 (default)|latest|main|<tag>|<branch>
+#   VLLM_CPU_DISABLE_AVX512=false (default)|true
+#   VLLM_CPU_AVX512BF16=false (default)|true
+#   VLLM_CPU_AVX512VNNI=false (default)|true
+
+###############################
+# Stage 1: Base Image
+###############################
+FROM registry.access.redhat.com/ubi10 AS base
+
+ARG PYTHON_VERSION=3.12
+ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ARG VLLM_VERSION="v0.10.0"
+ARG NUMACTL_VERSION=2.0.19
+
+USER 0
+
+WORKDIR /workspace
+
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    dnf -y update && \
+    INSTALL_PKGS="python3 python3-devel git wget gcc gcc-c++ cmake make" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    dnf clean all
+
+# Install uv (fast Python package installer)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    export PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
+
+# Set build environment variables
+ENV CFLAGS="-O3 -mavx2 -mf16c -fopenmp"
+ENV CXXFLAGS="${CFLAGS}"
+ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
+ENV VIRTUAL_ENV="/opt/venv"
+ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+ENV UV_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+ENV UV_PYTHON_INSTALL_DIR="/opt/uv/python"
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+ENV UV_LINK_MODE="copy"
+ENV UV_HTTP_TIMEOUT=500
+
+# Create virtual environment
+RUN uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Build numactl from source to get headers and libraries
+RUN --mount=type=cache,target=/tmp/numactl-build \
+    cd /tmp/numactl-build && \
+    wget -O numactl-${NUMACTL_VERSION}.tar.gz \
+    "https://github.com/numactl/numactl/releases/download/v${NUMACTL_VERSION}/numactl-${NUMACTL_VERSION}.tar.gz" && \
+    tar xf numactl-${NUMACTL_VERSION}.tar.gz && \
+    cd numactl-${NUMACTL_VERSION} && \
+    ./configure --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig
+
+# Clone vLLM source code at specific version
+# RUN git clone --depth 1 --branch $VLLM_VERSION https://github.com/vllm-project/vllm.git && \
+#     cd vllm && \
+#     git log --oneline -1
+
+# Install vLLM build and runtime dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,src=requirements/common.txt,target=requirements/common.txt \
+    --mount=type=bind,src=requirements/cpu.txt,target=requirements/cpu.txt \
+    uv pip install --upgrade pip && \
+    uv pip install -r requirements/cpu.txt
+
+###############################
+# Stage 2: Build Environment
+###############################
+FROM base AS builder
+
+ARG GIT_REPO_CHECK=0
+# Support for building with non-AVX512 vLLM: docker build --build-arg VLLM_CPU_DISABLE_AVX512="true" ...
+ARG VLLM_CPU_DISABLE_AVX512=false
+ARG VLLM_CPU_AVX512BF16=true
+ARG VLLM_CPU_AVX512VNNI=true
+
+ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
+ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
+ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
+
+WORKDIR /workspace/vllm
+COPY . .
+
+# Optional repository check
+RUN if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
+
+# install build requirements
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install -r requirements/cpu-build.txt
+
+# Build vLLM wheel
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,target=/workspace/vllm/.deps,sharing=locked \
+    VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel
+
+###############################
+# Stage 3: Runtime Environment
+###############################
+FROM registry.access.redhat.com/ubi10 AS runtime
+
+# Pass Python version to runtime stage
+ARG PYTHON_VERSION=3.12
+
+# Runtime environment variables
+# https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#related-runtime-environment-variables
+ARG VLLM_CPU_KVCACHE_SPACE=0
+ARG VLLM_CPU_OMP_THREADS_BIND=auto
+ARG VLLM_CPU_NUM_OF_RESERVED_CPU=None
+ARG CPU_VISIBLE_MEMORY_NODES=
+ARG VLLM_CPU_MOE_PREPACK=1
+ARG VLLM_CPU_SGL_KERNEL=0
+
+ENV VLLM_CPU_KVCACHE_SPACE=${VLLM_CPU_KVCACHE_SPACE}
+ENV VLLM_CPU_OMP_THREADS_BIND=${VLLM_CPU_OMP_THREADS_BIND}
+ENV VLLM_CPU_NUM_OF_RESERVED_CPU=${VLLM_CPU_NUM_OF_RESERVED_CPU}
+ENV CPU_VISIBLE_MEMORY_NODES=${CPU_VISIBLE_MEMORY_NODES}
+ENV VLLM_CPU_MOE_PREPACK=${VLLM_CPU_MOE_PREPACK}
+ENV VLLM_CPU_SGL_KERNEL=${VLLM_CPU_SGL_KERNEL}
+
+USER 0
+WORKDIR /workspace
+
+# Install Python 3.12 specifically and minimal runtime dependencies
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
+    dnf -y update && \
+    dnf install -y --setopt=tsflags=nodocs python3.12 python3.12-pip && \
+    dnf clean all && \
+    # Create symlinks to make Python 3.12 the default python3
+    ln -sf /usr/bin/python3.12 /usr/bin/python3 && \
+    ln -sf /usr/bin/pip3.12 /usr/bin/pip3
+
+# Copy artifacts from previous stages
+COPY --from=base /usr/local/lib/libnuma* /usr/local/lib/
+COPY --from=base /usr/local/bin/numa* /usr/local/bin/
+COPY --from=builder /workspace/vllm /workspace/vllm
+
+# Set up environment
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
+# Install vLLM wheel using Python 3.12 (no UV needed in runtime)
+ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+RUN --mount=type=bind,from=builder,src=/workspace/vllm/dist,target=/tmp \
+    echo "Python version:" && python3 --version && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install /tmp/*.whl && \
+    ldconfig
+
+# Set system-wide core dump limits
+RUN echo "* soft core 0" >> /etc/security/limits.conf && \
+    echo "* hard core 0" >> /etc/security/limits.conf
+
+# Create user
+RUN useradd -m -u 1001 -g root -s /bin/bash vllm
+
+# Verify installation with Python 3.12
+RUN python3 -c "import sys; print(f'Python version: {sys.version}')" && \
+    python3 -c "import vllm; print(f'vLLM {vllm.__version__} ready for runtime')" && \
+    numactl --version
+
+USER 1001
+WORKDIR /workspace/vllm
+
+# Start vLLM server using Python 3.12
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docker/Dockerfile.xeon-ubi
+++ b/docker/Dockerfile.xeon-ubi
@@ -1,26 +1,48 @@
-# Multi-stage vLLM Dockerfile for CPU-only UBI 10
+# Multi-stage vLLM Dockerfile for Intel Xeon CPUs on UBI9 and UBI10
+# Stage 0: Toolchain setup for UBI9 and UBI10
 # Stage 1: Build environment with all development tools
 # Stage 2: Build vLLM wheel
 # Stage 3: Minimal runtime environment with vLLM installed
 #
 # Build arguments:
 #   PYTHON_VERSION=3.13|3.12 (default)|3.11|3.10
-#   VLLM_VERSION=v0.11.0 (default)|latest|main|<tag>|<branch>
+#   VLLM_VERSION=main (default)|<tag>|<branch>
 #   VLLM_CPU_DISABLE_AVX512=false (default)|true
 #   VLLM_CPU_AVX512BF16=true (default)|false
 #   VLLM_CPU_AVX512VNNI=true (default)|false
+#   VLLM_CPU_AMXBF16=true (default)|false
 
+# Default to UBI9; can be overridden at build time with --build-arg UBI_VERSION=10
 ARG UBI_VERSION=9
+
+# UBI9 ships an older GCC lacking full AVX512 BF16 / AMX support, so we enable gcc-toolset-13.
+# UBI10 already has a recent GCC; installing gcc-toolset-13 there would fail (package not present).
+# Then we set CC and CXX accordingly for UBI9.
+###############################
+# Stage 0: Toolchain Setup
+###############################
+
+FROM registry.access.redhat.com/ubi9 AS toolchain-ubi9
+RUN dnf -y update && dnf install -y gcc gcc-c++ gcc-toolset-13 && dnf clean all
+ENV CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc
+ENV CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
+
+# UBI10 already has a recent GCC; we just set CC and CXX.
+FROM registry.access.redhat.com/ubi10 AS toolchain-ubi10
+RUN dnf -y update && dnf install -y gcc gcc-c++ && dnf clean all
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
 
 ###############################
 # Stage 1: Base Image
 ###############################
-FROM registry.access.redhat.com/ubi${UBI_VERSION} AS base
+FROM toolchain-ubi${UBI_VERSION} AS base
 
 ARG PYTHON_VERSION=3.12
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
-ARG VLLM_VERSION="v0.11.0"
+ARG VLLM_VERSION="main"
 ARG NUMACTL_VERSION=2.0.19
+ARG MARCH="sapphirerapids"
 
 USER 0
 
@@ -28,7 +50,7 @@ WORKDIR /workspace
 
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf -y update && \
-    INSTALL_PKGS="python3 python3-devel git wget gcc gcc-c++ cmake make" && \
+    INSTALL_PKGS="python3 python3-devel git wget cmake make" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf clean all
@@ -38,8 +60,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     export PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
 
 # Set build environment variables
-ENV CFLAGS="-O3 -mavx2 -mf16c -fopenmp"
+# Redundant for -march=sapphirerapids and onwards (https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html):
+# -mavx2 -mf16c -mavx512f -mavx512vnni -mavx512bf16 -mamx-tile -mamx-int8 -mamx-bf16
+ENV CFLAGS="-march=${MARCH} -O3 -fopenmp"
 ENV CXXFLAGS="${CFLAGS}"
+ENV CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"
 ENV LD_LIBRARY_PATH="/usr/local/lib:"
 ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
 ENV VIRTUAL_ENV="/opt/venv"
@@ -87,10 +112,14 @@ ARG GIT_REPO_CHECK=0
 ARG VLLM_CPU_DISABLE_AVX512=false
 ARG VLLM_CPU_AVX512BF16=true
 ARG VLLM_CPU_AVX512VNNI=true
+# Support for building with AMXBF16 ISA
+ARG VLLM_CPU_AMXBF16=true
 
 ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
 ENV VLLM_CPU_AVX512BF16=${VLLM_CPU_AVX512BF16}
 ENV VLLM_CPU_AVX512VNNI=${VLLM_CPU_AVX512VNNI}
+ENV VLLM_CPU_AMXBF16=${VLLM_CPU_AMXBF16}
+ENV VLLM_TARGET_DEVICE=cpu
 
 WORKDIR /workspace/vllm
 
@@ -104,7 +133,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # Build vLLM wheel
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/workspace/vllm/.deps,sharing=locked \
-    VLLM_TARGET_DEVICE=cpu python3 setup.py bdist_wheel
+    python3 setup.py bdist_wheel --dist-dir=dist
 
 ###############################
 # Stage 3: Runtime Environment
@@ -117,7 +146,7 @@ ARG GPERFTOOLS_VERSION=2.17.2
 # Runtime environment variables
 # https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#related-runtime-environment-variables
 # Larger space can support more concurrent requests, longer context length.
-ARG VLLM_CPU_KVCACHE_SPACE=64
+ARG VLLM_CPU_KVCACHE_SPACE=40
 ARG VLLM_CPU_OMP_THREADS_BIND=auto
 # - Note, it is recommended to manually reserve 1 CPU for vLLM front-end process when world_size == 1.
 #   - Unset VLLM_CPU_NUM_OF_RESERVED_CPU for world size > 1
@@ -175,10 +204,10 @@ cd /tmp/gperftools-build && \
 
 # Install vLLM wheel using Python 3.12 (no UV needed in runtime)
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
-RUN --mount=type=bind,from=builder,src=/workspace/vllm/dist,target=/tmp \
+RUN --mount=type=bind,from=builder,src=/workspace/vllm/dist,target=dist \
     echo "Python version:" && python3 --version && \
     python3 -m pip install --upgrade pip && \
-    python3 -m pip install /tmp/*.whl && \
+    python3 -m pip install dist/*.whl && \
     ldconfig
 
 # Set up environment
@@ -194,8 +223,7 @@ RUN useradd -m -u 1001 -g root -s /bin/bash vllm
 
 # Verify installation with Python 3.12
 RUN python3 -c "import sys; print(f'Python version: {sys.version}')" && \
-    python3 -c "import vllm; print(f'vLLM {vllm.__version__} ready for runtime')" && \
-    numactl --version
+    python3 -c "import vllm; print(f'vLLM {vllm.__version__} ready for runtime')"
 
 USER 1001
 


### PR DESCRIPTION
## Dockerfile with vLLM dedicated to running on CPU (Xeon). Based on UBI.
Edits:
- _14-11-2025_:
  - Switched from `v.0.11.0` to `main` branch of vLLM
  - Set `-march=sapphirerapids` as default build target (AVX512, AMX enabled by default)
  - vLLM builds with `VLLM_CPU_AMXBF16` flag - it was added about 3 days ago to upstream
  - Fixed `VLLM_CPU_SGL_KERNEL` not working on UBI9 - **now it's working on both UBI9 and UBI10**
  - Set the default value of `VLLM_CPU_KVCACHE_SPACE` to 40GB
  - Simpler build commands, no need to disable `VLLM_CPU_SGL_KERNEL` for UBI9
- _10-23-2025: Added an option to specify UBI version, tested on UBI9 and UBI10._
  - `VLLM_CPU_SGL_KERNEL=1` works on UBI10, however NOT on UBI9 due to older `glibc` - need to be set to `0` for UBI9 runtime.
- _10-21-2025: Updated to match changes introduced in https://github.com/RHRolun/vllm/pull/5/commits/fe00388a75f0280af71069d2c68137c3f53c9da6_
  - Use tcmalloc for better performance
  - Downloads vLLM from upstream based on `VLLM_VERSION`
  - Adds additional tuning environmental variables
  - All optimizations are enabled by default
    - Users only need to specify `VLLM_CPU_KVCACHE_SPACE` based on system memory
  - Correctly sets `LD_PRELOAD` to use `libtcmalloc_minimal.so.4` and `libiomp5.so`
---
### Building the docker image
- For Xeon optimizations , you just have to build it with default values.
- UBI9 (default):
```
docker build -f Dockerfile.xeon-ubi -t vllm-ubi9:latest .
```
- UBI10:
```
docker build -f Dockerfile.xeon-ubi  --build-arg UBI_VERSION=10 -t vllm-ubi10:latest .
```
---
### Running the docker container
- Specify `VLLM_CPU_KVCACHE_SPACE`; it must be lower than your system memory, 40GB by default. Larger KV Cache can support more concurrent requests and longer context length. 
- UBI9:
```
docker run -d \
  -p 8000:8000 \
  -e VLLM_CPU_KVCACHE_SPACE=96 \
  -e HF_TOKEN=<YOUR_HF_TOKEN> \
  vllm-xeon-ubi:latest \
    --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
    --host 0.0.0.0 \
    --port 8000 \
    --dtype bfloat16
```
- UBI10:
```
docker run -d \
  -p 8000:8000 \
  -e VLLM_CPU_KVCACHE_SPACE=96 \
  -e HF_TOKEN=<YOUR_HF_TOKEN> \
  vllm-xeon-ubi:latest \
    --model TinyLlama/TinyLlama-1.1B-Chat-v1.0 \
    --host 0.0.0.0 \
    --port 8000 \
    --dtype bfloat16
```

- When building for machines without `avx512f`, `avx512_bf16`, `avx512_vnni` or `amx` you need to disable build optimizations using `--build-arg`
```
docker build -f docker/Dockerfile.xeon-ubi\
        --build-arg VLLM_CPU_AVX512BF16=false \
        --build-arg VLLM_CPU_AVX512VNNI=false \
        --build-arg VLLM_CPU_DISABLE_AVX512=true \ 
        --build-arg VLLM_CPU_AMXBF16=false
        --tag vllm-xeon-ubi
```
This assumes your machine has the `amx` CPU flag (SPR and onwards), enabled by default:
- `VLLM_CPU_MOE_PREPACK` can provide better performance for MoE models
- `VLLM_CPU_SGL_KERNEL` can provide better performance for MoE models and small-batch scenarios
  -  ~~Set to 1 to enable if your CPU supports it. Works on UBI10, but not on UBI9 due to older `glibc`~~ **fixed.**
- More details
  - [docs.vllm.ai/en/stable/getting_started/installation/cpu.html#build-image-from-source](https://docs.vllm.ai/en/stable/getting_started/installation/cpu.html#build-image-from-source)


